### PR TITLE
Executing eslint binary options refactor #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ coverage
 node_modules
 typings
 *.orig
+typings

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "0.10"
   - "0.12"
 notifications:
   webhooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,6 @@ notifications:
     on_start: false     # default: false
 before_install:
   - npm install -g mocha
+  - npm install --save eslint
 script:
   - npm run ci

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Eslint Watch ([Release Notes](https://github.com/rizowski/eslint-watch/releases/latest))
 [![Build Status](https://travis-ci.org/rizowski/eslint-watch.svg?branch=master)](https://travis-ci.org/rizowski/eslint-watch)
+[![Build status](https://ci.appveyor.com/api/projects/status/0v5dn6wqofyp6ldb/branch/master?svg=true)](https://ci.appveyor.com/project/rizowski/eslint-watch/branch/master)
 [![NPM version](https://badge.fury.io/js/eslint-watch.svg)](http://badge.fury.io/js/eslint-watch)
 [![Dependancies](https://david-dm.org/rizowski/eslint-watch.svg)](https://david-dm.org/rizowski/eslint-watch#info=dependencies)
 [![devDependency Status](https://david-dm.org/rizowski/eslint-watch/dev-status.svg)](https://david-dm.org/rizowski/eslint-watch#info=devDependencies)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,17 @@
+version: '{build}'
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of io.js
+  - ps: Install-Product node ''
+  - npm -g install npm@latest
+  - set PATH=%APPDATA%\npm;%PATH%
+  - node --version
+  - npm --version
+  - npm install
+
+# No need for MSBuild on this project
+build: off
+
+test_script:
+  - npm test

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,5 +13,9 @@ install:
 # No need for MSBuild on this project
 build: off
 
+notifications:
+  - provider: Webhook
+    url: https://webhooks.gitter.im/e/2c5e0e441ca25c240df9
+
 test_script:
-  - npm test
+  - npm run ci

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-watch",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Run eslint with watch mode",
   "main": "./src/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-watch",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Run eslint with watch mode",
   "main": "./src/cli.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "chai": "^2.3.0",
+    "child-process-promise": "^1.1.0",
     "istanbul": "^0.3.14",
     "mocha": "^2.2.5",
     "sinon": "^1.14.1",

--- a/spec/arg-parser-spec.js
+++ b/spec/arg-parser-spec.js
@@ -7,24 +7,24 @@ chai.use(sinonChai);
 
 var expect = chai.expect;
 
-describe('arg-parser', function(){
+describe('arg-parser', function () {
   var parser, options;
-  before(function(){
+  before(function () {
     parser = require('../src/arg-parser');
   });
 
-  beforeEach(function(){
-    options = {'_': []};
+  beforeEach(function () {
+    options = { '_': [] };
   });
 
-  describe('watch', function(){
-    it('parses for -w', function(){
+  describe('watch', function () {
+    it('parses for -w', function () {
       var args = ['node', 'some/long/path/to/prog', '-w'];
       var arr = parser.parse(args, options);
       expect(arr).to.not.contain('-w');
     });
 
-    it('parses for --watch', function(){
+    it('parses for --watch', function () {
       var watch = '--watch';
       var args = ['node', 'some/long/path/to/prog', watch];
       var arr = parser.parse(args, options);
@@ -32,13 +32,13 @@ describe('arg-parser', function(){
     });
   });
 
-  describe('path', function(){
-    it('sets a default path if one isn\'t provided', function(){
+  describe('path', function () {
+    it('sets a default path if one isn\'t provided', function () {
       var arr = parser.parse([], options);
       expect(arr).to.contain('./');
     });
 
-    it('doesn\'t set the default if a path is provided', function(){
+    it('doesn\'t set the default if a path is provided', function () {
       var path = 'something/short/';
       options._.push(path);
       var arr = parser.parse([], options);
@@ -46,50 +46,66 @@ describe('arg-parser', function(){
     });
   });
 
-  describe('formatters', function(){
-    var find = function(arr, what){
+  describe('executors', function(){
+    it('parses out node', function(){
+      var node = 'node';
+      var args = [node, 'some/path/somewhere'];
+      var arr = parser.parse(args, options);
+      expect(arr).to.not.contain(node);
+    });
+
+    it('parses out esw', function(){
+      var esw = 'var/esw';
+      var args = ['something', esw];
+      var arr = parser.parse(args, options);
+      expect(arr).to.not.contain(esw);
+    });
+  });
+
+  describe('formatters', function () {
+    var find = function (arr, what) {
       var result = false;
-      for(var i = 0; i < arr.length; i++){
+      for (var i = 0; i < arr.length; i++) {
         result = result || arr[i].indexOf(what) > -1;
       }
       return result;
     };
-    var occurance = function(arr, what){
+    var occurance = function (arr, what) {
       var result = 0;
-      for(var i = 0; i < arr.length; i++){
-        if(arr[i].indexOf(what) > -1){
+      for (var i = 0; i < arr.length; i++) {
+        if (arr[i].indexOf(what) > -1) {
           result += 1;
         }
       }
       return result;
     };
     var pathStub;
-    beforeEach(function(){
+    beforeEach(function () {
       var path = require('path');
-      pathStub = sinon.stub(path, 'join', function(){
+      pathStub = sinon.stub(path, 'join', function () {
         return 'src\\' + arguments[1] + '\\' + arguments[2];
       });
     });
 
-    afterEach(function(){
+    afterEach(function () {
       pathStub.restore();
     });
 
-    it('sets the full path to the formatters folder', function(){
+    it('sets the full path to the formatters folder', function () {
       options.format = 'simple';
       var arr = parser.parse(['-f', 'simple'], options);
       var result = find(arr, 'src\\formatters\\simple');
       expect(result).to.be.true;
     });
 
-    it('sets the default formatter to simple-detail using args', function(){
+    it('sets the default formatter to simple-detail using args', function () {
       options.format = 'simple-detail';
       var arr = parser.parse(['-f', 'simple-detail'], options);
       var result = find(arr, 'formatters\\simple-detail');
       expect(result).to.be.true;
     });
 
-    it('handles passing in default', function(){
+    it('handles passing in default', function () {
       options.format = 'simple-detail';
       var arr = parser.parse(['-f', 'simple-detail'], options);
       var result = occurance(arr, 'formatters\\simple-detail');

--- a/spec/eslint-cli-spec.js
+++ b/spec/eslint-cli-spec.js
@@ -11,7 +11,7 @@ describe('eslint-cli', function () {
   var cli;
   var platform = 'win32';
   var osStub;
-  var childStub;
+  var childSpy;
   var pathStub;
   var os;
   var path;
@@ -28,9 +28,8 @@ describe('eslint-cli', function () {
     osStub = sinon.stub(os, 'platform', function(){
       return platform;
     });
-    childStub = sinon.stub(child, 'spawn', function(prog, args, opts){
-      return {prog: prog, args: args, opts: opts};
-    });
+    childSpy = sinon.spy(child.spawn);
+
     pathStub = sinon.stub(path, 'resolve', function(){
       return arguments;
     });
@@ -38,28 +37,20 @@ describe('eslint-cli', function () {
 
   afterEach(function(){
     osStub.restore();
-    childStub.restore();
     pathStub.restore();
   });
 
   it('executes eslint.cmd for win32', function(){
-    var args = ['-f', 'simple', './'];
+    var args = ['-a', 'simple', './'];
     platform = 'win32';
-    var results = cli(args);
-    console.log(results);
-    expect(results.prog).to.equal('./node_modules/.bin/eslint.cmd');
+    cli(args);
+    expect(childSpy.calledWith('./node_modules/.bin/eslint.cmd', args, {stdio: 'inherit'}));
   });
 
   it('executes eslint for other os', function(){
-    var args = ['-f', 'simple', './'];
+    var args = ['-a', 'simple', './'];
     platform = 'osx';
-    var results = cli(args);
-    expect(results.prog).to.equal('./node_modules/.bin/eslint');
-  });
-
-  it('executes eslint', function(){
-    var args = ['-f', 'simple', './'];
-    var results = cli(args);
-    expect(results.args).to.equal(args);
+    cli(args);
+    expect(childSpy.calledWith('./node_modules/.bin/eslint', args, {stdio: 'inherit'}));
   });
 });

--- a/spec/eslint-cli-spec.js
+++ b/spec/eslint-cli-spec.js
@@ -1,0 +1,65 @@
+'use strict';
+var chai = require('chai');
+var sinon = require('sinon');
+var sinonChai = require('sinon-chai');
+
+chai.use(sinonChai);
+
+var expect = chai.expect;
+
+describe('eslint-cli', function () {
+  var cli;
+  var platform = 'win32';
+  var osStub;
+  var childStub;
+  var pathStub;
+  var os;
+  var path;
+  var child;
+
+  before(function(){
+    os = require('os');
+    child = require('child-process-promise');
+    path = require('path');
+    cli = require('../src/eslint-cli');
+  });
+
+  beforeEach(function(){
+    osStub = sinon.stub(os, 'platform', function(){
+      return platform;
+    });
+    childStub = sinon.stub(child, 'spawn', function(prog, args, opts){
+      return {prog: prog, args: args, opts: opts};
+    });
+    pathStub = sinon.stub(path, 'resolve', function(){
+      return arguments;
+    });
+  });
+
+  afterEach(function(){
+    osStub.restore();
+    childStub.restore();
+    pathStub.restore();
+  });
+
+  it('executes eslint.cmd for win32', function(){
+    var args = ['-f', 'simple', './'];
+    platform = 'win32';
+    var results = cli(args);
+    console.log(results);
+    expect(results.prog).to.equal('./node_modules/.bin/eslint.cmd');
+  });
+
+  it('executes eslint for other os', function(){
+    var args = ['-f', 'simple', './'];
+    platform = 'osx';
+    var results = cli(args);
+    expect(results.prog).to.equal('./node_modules/.bin/eslint');
+  });
+
+  it('executes eslint', function(){
+    var args = ['-f', 'simple', './'];
+    var results = cli(args);
+    expect(results.args).to.equal(args);
+  });
+});

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -15,8 +15,17 @@ var formats = { // still don't like this can cause too much duplication
   'simple-success': true,
   'simple-detail': true
 };
+var bin = {
+  'node': true,
+  'esw': 'esw'
+};
+
 var getPath = function(options){
   return path.join(__dirname, formatterPath, options.format);
+};
+
+var contains = function(str, item){
+  return str.indexOf(item) >= 0;
 };
 
 module.exports = {
@@ -27,7 +36,7 @@ module.exports = {
 
     for (var i = 0; i < args.length; i++) {
       var item = args[i];
-      if (!keys[item] && !formats[item]) {
+      if (!keys[item] && !formats[item] && !bin[item] && !contains(item, bin.esw)) {
         arr.push(item);
       }
       if (formats[item]) {

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,7 +15,12 @@ currentOptions = options.parse(args);
 eslArgs = argParser.parse(args, currentOptions);
 
 if (!currentOptions.help) {
-  eslint(eslArgs);
+  eslint(eslArgs)
+    .catch(function(err){
+      if(err.code){
+        exitCode = err.code;
+      }
+    });
 
   if (currentOptions.watch) {
     watcher(currentOptions);

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,7 +1,7 @@
 /* eslint no-process-exit: 0*/
 'use strict';
 var options = require('./options');
-var cli = require('./eslint-cli');
+var eslint = require('./eslint-cli');
 var watcher = require('./watcher');
 var argParser = require('./arg-parser');
 
@@ -15,7 +15,7 @@ currentOptions = options.parse(args);
 eslArgs = argParser.parse(args, currentOptions);
 
 if (!currentOptions.help) {
-  exitCode = cli.execute(eslArgs);
+  eslint(eslArgs);
 
   if (currentOptions.watch) {
     watcher(currentOptions);

--- a/src/eslint-cli.js
+++ b/src/eslint-cli.js
@@ -2,9 +2,9 @@
 var child = require('child-process-promise');
 var path = require('path');
 var os = require('os');
+
 var cmd = os.platform() === 'win32' ? '.cmd' : '';
 var eslint = path.resolve('./node_modules/.bin/eslint' + cmd);
-
 var exec = child.spawn;
 
 module.exports = function(args){

--- a/src/eslint-cli.js
+++ b/src/eslint-cli.js
@@ -1,2 +1,16 @@
 'use strict';
-module.exports = require('eslint/lib/cli');
+var child = require('child-process-promise');
+var path = require('path');
+var os = require('os');
+var cmd = os.platform() === 'win32' ? '.cmd' : '';
+var eslint = path.resolve('./node_modules/.bin/eslint' + cmd);
+
+var exec = child.spawn;
+
+module.exports = function(args){
+  return exec(eslint, args, { stdio: 'inherit' })
+    .catch(function(){
+      //console.log(err);
+      // process.exit(1);
+    });
+};

--- a/src/eslint-cli.js
+++ b/src/eslint-cli.js
@@ -8,9 +8,5 @@ var eslint = path.resolve('./node_modules/.bin/eslint' + cmd);
 var exec = child.spawn;
 
 module.exports = function(args){
-  return exec(eslint, args, { stdio: 'inherit' })
-    .catch(function(){
-      //console.log(err);
-      // process.exit(1);
-    });
+  return exec(eslint, args, { stdio: 'inherit' });
 };

--- a/src/options.js
+++ b/src/options.js
@@ -8,106 +8,20 @@ module.exports = optionator({
   options: [{
     heading: 'Options'
   }, {
-      option: 'help',
-      alias: 'h',
-      type: 'Boolean',
-      description: 'Show help'
-    }, {
-      option: 'config',
-      alias: 'c',
-      type: 'path::String',
-      description: 'Use configuration from this file'
-    }, {
-      option: 'rulesdir',
-      type: '[path::String]',
-      description: 'Use additional rules from this directory'
-    }, {
-      option: 'format',
-      alias: 'f',
-      type: 'String',
-      default: 'simple-detail',
-      description: 'Use a specific output format'
-    }, {
-      option: 'version',
-      alias: 'v',
-      type: 'Boolean',
-      description: 'Outputs the version number'
-    }, {
-      option: 'reset',
-      type: 'Boolean',
-      default: 'false',
-      description: 'Set all default rules to off'
-    }, {
-      option: 'eslintrc',
-      type: 'Boolean',
-      default: 'true',
-      description: 'Disable use of configuration from .eslintrc'
-    }, {
-      option: 'env',
-      type: '[String]',
-      description: 'Specify environments'
-    }, {
-      option: 'ext',
-      type: '[String]',
-      default: '.js',
-      description: 'Specify JavaScript file extensions'
-    }, {
-      option: 'plugin',
-      type: '[String]',
-      description: 'Specify plugins'
-    }, {
-      option: 'global',
-      type: '[String]',
-      description: 'Define global variables'
-    }, {
-      option: 'rule',
-      type: 'Object',
-      description: 'Specify rules'
-    },
-    {
-      option: 'ignore-path',
-      type: 'path::String',
-      description: 'Specify path of ignore file'
-    },
-    {
-      option: 'ignore',
-      type: 'Boolean',
-      default: 'true',
-      description: 'Disable use of .eslintignore'
-    },
-    {
-      option: 'color',
-      type: 'Boolean',
-      default: 'true',
-      description: 'Disable color in piped output'
-    },
-    {
-      option: 'output-file',
-      alias: 'o',
-      type: 'path::String',
-      description: 'Specify file to write report to'
-    },
-    {
-      option: 'quiet',
-      type: 'Boolean',
-      default: 'false',
-      description: 'Report errors only'
-    },
-    {
-      option: 'stdin',
-      type: 'Boolean',
-      default: 'false',
-      description: 'Lint code provided on <STDIN>'
-    },
-    {
-      option: 'stdin-filename',
-      type: 'String',
-      description: 'Specify filename to process STDIN as'
-    },
-    {
-      option: 'watch',
-      alias: 'w',
-      type: 'Boolean',
-      description: 'Enable file watch'
+    option: 'help',
+    alias: 'h',
+    type: 'Boolean',
+    description: 'Show help'
+  }, {
+    option: 'format',
+    alias: 'f',
+    type: 'String',
+    default: 'simple-detail',
+    description: 'Use a specific output format'
+  }, {
+    option: 'watch',
+    alias: 'w',
+    type: 'Boolean',
+    description: 'Enable file watch'
     }]
 });


### PR DESCRIPTION
- [x] Make eslint executable using node_modules bin binary
- [X] Parse out the first two commands `node` and `esw` path
  - [X] Tests written
- [ ] Refactor arg-parser so the conditional statements make sense
- [x] Build server passes on node 0.10
- [ ] Help options are displayed when option is asked for
  - [ ] ESLint's help is displayed
  - [ ] ESLint watch help is appended
- [x] process.exit is called on single lint, watch option doesn't stop the thread
