### PR TITLE
Fixes no output by correcting lodash  syntax

### DIFF
--- a/src/eslint/help.js
+++ b/src/eslint/help.js
@@ -44,7 +44,7 @@ function parseRegular(arr){
 function parseHelp(helpText){
   var helpArr = helpText.split('\n');
   var newArr = [];
-  _.each(helpArr, function(row, index){
+  _.each(function(newArr, row, index){
     if(index === 0 || index === 1 || index === 2){
       return;
     } else {


### PR DESCRIPTION
This lodash syntax error was resulting in no output when you run `esw`. I believe this might be related to #30.