### PR TITLE
Fixing --color, --no-color #81

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ notifications:
     on_failure: always  # options: [always|never|change] default: always
     on_start: false     # default: false
 before_install:
-  - npm install eslint@1
+  - npm install eslint@2
 script:
   - npm run ci
 after_success:

--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
     "eslint": ">=0.19.0 <3.0.0"
   },
   "dependencies": {
-    "chalk": "^1.0.0",
-    "chokidar": "^1.0.1",
+    "chalk": "^1.1.3",
+    "chokidar": "^1.4.3",
     "debug": "^2.2.0",
     "keypress": "^0.2.1",
     "lodash": "^3.10.1",
@@ -52,11 +52,11 @@
   "devDependencies": {
     "chai": "^3.4.0",
     "eslint": "2",
-    "istanbul": "^0.4.0",
+    "istanbul": "^0.4.3",
     "mocha": "^2.2.5",
     "mocha-sinon": "^1.1.4",
     "proxyquire": "^1.6.0",
-    "sinon": "^1.14.1",
+    "sinon": "^1.17.4",
     "sinon-chai": "^2.7.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Run eslint with watch mode",
   "main": "./src/cli.js",
   "scripts": {
+    "eslint": "eslint ./",
     "lint": "node ./bin/esw",
     "lw": "node ./bin/esw -w",
     "test": "mocha spec --recursive -R spec --timeout 10000",
@@ -50,6 +51,7 @@
   },
   "devDependencies": {
     "chai": "^3.4.0",
+    "eslint": "2",
     "istanbul": "^0.4.0",
     "mocha": "^2.2.5",
     "mocha-sinon": "^1.1.4",

--- a/spec/eslint/help-spec.js
+++ b/spec/eslint/help-spec.js
@@ -14,6 +14,7 @@ describe('eslint/help', function(){
   var noAlias = '--see String     no alias';
   var noType = '-n --nope      no type to be found here';
   var noColor = '  --no-color                  Disable color in piped output';
+  var doubleExample = '--color, --no-color       Enables or disables color piped output';
   var msg;
   var help;
 
@@ -186,6 +187,26 @@ describe('eslint/help', function(){
         var colorOption = options[0];
         expect(colorOption.default).to.equal('true');
         done();
+       });
+  });
+
+  it('can parse doubled option options', function(done){
+    msg = title + '\n' +
+       '\n' +
+       optionsTxt + '\n' +
+       helpTxt + '\n' +
+       '\n' +
+       'HEADING:\n'+
+       doubleExample + '\n';
+       help(function(options){
+         var colorOption = options[0];
+         expect(colorOption).to.eql({
+           option: 'color',
+           type: 'Boolean',
+           alias: 'no-color',
+           description: 'Enables or disables color piped output'
+         });
+         done();
        });
   });
 });

--- a/src/eslint/help.js
+++ b/src/eslint/help.js
@@ -85,9 +85,7 @@ function parseHelp(helpText){
       return;
     } else {
       var str = row.replace(',', '');
-      // console.log(str);
       var arr = str.trim().split(' ');
-      // console.log(arr);
       if(str.indexOf('-') >= 0 && previousLine[0] !== ''){
         var option = createOption(arr);
         if(option && option.option !== 'format' && option.option !== 'help'){


### PR DESCRIPTION
This should fix help options being outputted from eslint in this format

Boken by: https://github.com/eslint/eslint/pull/5974

```
--color, --no-color        Force enabling/disabling of color
```