### PR TITLE
add more options to watcher so that watcher can be run on ecmaVersion 6

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -20,7 +20,7 @@ var cliOptionProperties = [
   'config', 'eslintrc', 'ext',
   'parser', 'cache', 'cacheLocation',
   'ignore', 'ignorePath', 'ignorePattern',
-  'fix'
+  'fix', 'parserOptions', 'global'
 ];
 var cliOptionMap = {
   config: 'configFile',


### PR DESCRIPTION
In order to be able to watch my es6 files I made this change. 

If there is some configuration option I can  set to work with my files instead that would also be great.