### PR TITLE
Changed the watcher to require the specified formatter upon init

### DIFF
--- a/tests/watcher-spec.js
+++ b/tests/watcher-spec.js
@@ -60,18 +60,18 @@ describe('Watcher', function () {
   });
 
   it('calls the on event', function(){
-    watcher({ _: [] });
+    watcher({ _: [], format: 'simple-detail' });
     expect(onSpy.called).to.be.true;
   });
 
   it('watches the directories under _ attribute', function() {
     var arr = ['hello'];
-    watcher({ _: arr });
+    watcher({ _: arr, format: 'simple-detail' });
     expect(watcherOptions).to.equal(arr);
   });
 
   it('calls the on changed event', function() {
-    watcher({ _: [] });
+    watcher({ _: [], format: 'simple-detail' });
     expect(onSpy).to.have.been.calledWith('change');
   });
 });


### PR DESCRIPTION
Changed the watcher to require the specified formatter upon initializtion. Checked lint and fixed tests.

### What was the problem/Ticket Number
#108

### How does this solve the problem?
Changes behaviour of watcher to call require('path/to/formatter') at runtime when the watcher is set up. This formatter is then used when re-linting.
The runtime call to require() mirrors the behaviour of ESLint itself.

### How to duplicate the issue

  1. create a basic ESLint formatter outside the project
  2. run eslint-watch from the command line specifying the path to the new formatter using the -f option
  3. initial lint output should be from the new formatter
  4. change a watched file.
before this fix, the linter would revert to use simple-detail, Now, it uses the passed option.
Options tested include the formatters built in to eslint-watch (simple, simple-detail, simple-success), and full paths to any other formatter.