### PR TITLE
Add --clear option to clear terminal on each eslint run

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "babel-core": "^6.21.0",
     "babel-eslint": "^6.1.2",
     "babel-plugin-add-module-exports": "^0.2.1",
-    "babel-preset-env": "^1.1.8",
+    "babel-preset-env": "^1.3.3",
     "chai": "^3.5.0",
     "eslint": "3",
     "eslint-config-rizowski": "^1.0.2",

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -15,6 +15,7 @@ const keys = {
   '-w': true,
   '--watch': true,
   '--changed': true,
+  '--clear': true,
   '--esw-version': true
 };
 const formats = {

--- a/src/formatters/helpers/clear-terminal.js
+++ b/src/formatters/helpers/clear-terminal.js
@@ -1,0 +1,3 @@
+export default function clearTerminal() {
+  process.stdout.write('\x1Bc');
+}

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ import watcher from './watcher';
 import argParser from './arg-parser';
 import Logger from './logger';
 import pkg from '../package';
+import clearTerminal from './formatters/helpers/clear-terminal.js';
 
 const logger = Logger('esw-cli');
 
@@ -58,6 +59,9 @@ if(parsedOptions.eswVersion){
   const eslArgs = argParser.parse(args, parsedOptions);
   if (!parsedOptions.help) {
     logger.debug('Running initial lint');
+    if (parsedOptions.clear) {
+      clearTerminal();
+    }
     runLint(eslArgs, parsedOptions);
     if (parsedOptions.watch) {
       logger.debug('-w seen');

--- a/src/options.js
+++ b/src/options.js
@@ -31,11 +31,15 @@ const myOptions = [{
   alias: 'w',
   type: 'Boolean',
   description: 'Enable file watch'
-},{
+}, {
   option: 'changed',
   type: 'Boolean',
   description: 'Enables single file linting while watch is enabled'
-},{
+}, {
+  option: 'clear',
+  type: 'Boolean',
+  description: 'Clear terminal when running lint'
+}, {
   option: 'esw-version',
   type: 'Boolean',
   description: "Prints Eslint-Watch's Version"

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -5,6 +5,7 @@ import path from 'path';
 
 import settings from './settings';
 import Logger from './logger';
+import clearTerminal from './formatters/helpers/clear-terminal.js';
 
 const logger = Logger('watcher');
 
@@ -80,6 +81,9 @@ export default function watcher(options) {
 
   function lintFile(path) {
     logger.debug('lintFile: %s', path);
+    if (options.clear) {
+      clearTerminal();
+    }
     let report = cli.executeOnFiles(path);
     if (options.fix) {
       eslint.CLIEngine.outputFixes(report);


### PR DESCRIPTION
### What was the problem/Ticket Number

See issue #110 

### How does this solve the problem?

Adds --clear option to clear the terminal on each run of eslint.

### How to duplicate the issue

  1. `esw -w --clear ...`
  2. Enjoy automatic terminal clears on each eslint run.
