### PR TITLE
Check if key is defined

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,12 +35,12 @@ function keyListener(args, options){
   keypress(stdin);
   stdin.on('keypress', function keyPressListener(ch, key){
     logger.debug('%s was pressed', key.name);
-    if(key.name === 'return'){
+    if(key && key.name === 'return'){
       logger.debug('relinting...');
       logger.debug(options);
       runLint(args, options);
     }
-    if(key.ctrl && key.name === 'c') {
+    if(key && key.ctrl && key.name === 'c') {
       process.exit();
     }
   });


### PR DESCRIPTION
### What was the problem/Ticket Number
When the tool is running and you press a non-character key (e.g. 1, 2, 3, comma, period), the tool crashes since `key` is undefined.

### How does this solve the problem?
Add a check to make sure that `key` is defined.

### How to duplicate the issue

  1. Run the tool in watch mode
  2. Press any non-character key like 1.
