### PR TITLE
Make gray text readable on Solarized Dark theme

### DIFF
--- a/src/formatters/simple-detail.js
+++ b/src/formatters/simple-detail.js
@@ -24,7 +24,7 @@ function simpleDetail(results) {
   let totalWarnings = 0;
   let output = '';
   let cleanMsg = '';
-  let messageTime = chalk.gray(`(${new Date().toLocaleTimeString()})`);
+  let messageTime = chalk.dim(`(${new Date().toLocaleTimeString()})`);
   logger.debug(results);
   results.forEach(function (result) {
     let messages = result.messages;
@@ -53,12 +53,12 @@ function simpleDetail(results) {
           message.line || 0,
           message.column || 0,
           chalk.dim(message.message.replace(/\.$/, '')),
-          chalk.gray(message.ruleId || '')];
+          chalk.dim(message.ruleId || '')];
       }), tableSettings);
 
     output += chalk.white.underline(result.filePath) + ` (${chalk.red(errors)}/${chalk.yellow(warnings)})${c.endLine}`;
     output += tableText.split(c.endLine).map(function (el) {
-      return el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.gray(`${p1}:${p2}`));
+      return el.replace(/(\d+)\s+(\d+)/, (m, p1, p2) => chalk.dim(`${p1}:${p2}`));
     }).join(c.endLine) + c.endLine + c.endLine;
   });
 


### PR DESCRIPTION
### What was the problem/Ticket Number
Gray text is unreadable with Solarized Dark theme

### How does this solve the problem?
Makes the text readable again

### How to duplicate the issue

  1. Install Solarized Dark theme
  2. Run esw with simple-detail formatter
  3. Create an lint error
  4. Try to read the output in the terminal

See:
https://github.com/eslint/eslint/pull/4885
https://github.com/altercation/solarized/issues/220
https://github.com/chalk/chalk/issues/40

Before
![image](https://user-images.githubusercontent.com/82148/27125289-1f3c42b6-50f4-11e7-9edc-f089602912a4.png)

After
![image](https://user-images.githubusercontent.com/82148/27125252-fa5f4f74-50f3-11e7-9a87-6a3df6884ed8.png)
