### PR TITLE
Check if key is defined when logging

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,7 @@ function keyListener(args, options){
   }
   keypress(stdin);
   stdin.on('keypress', function keyPressListener(ch, key){
-    logger.debug('%s was pressed', key.name);
+    logger.debug('%s was pressed', key ? key.name : ch);
     if(key && key.name === 'return'){
       logger.debug('relinting...');
       logger.debug(options);


### PR DESCRIPTION
### What was the problem/Ticket Number

This is a continuation of #116. I forgot to take one more case into account. The tool still crashes when pressing a number in watch mode. This is due to the logging line.

### How does this solve the problem?

Make sure that `key` is defined before getting the `name` property from it during logging.

### How to duplicate the issue
As before,

1. Run the tool in watch mode
2. Press a number key like 1.
3. The tool will then crash.