### PR TITLE
Fix various lint inconsistencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,14 @@
   },
   "parserOptions": {
     "sourceType": "module"
+  },
+  "rules": {
+    "brace-style": "error",
+    "comma-dangle": "error",
+    "keyword-spacing": "error",
+    "quotes": ["error", "single"],
+    "space-before-blocks": "error",
+    "space-before-function-paren": ["error", {"anonymous": "always", "named": "never"}],
+    "space-infix-ops": "error"
   }
 }

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -24,7 +24,7 @@ const formats = {
   'simple-detail': true
 };
 
-const getPath = function getPath(options){
+const getPath = function getPath(options) {
   logger.debug('GetPath: %s', options.format);
   const formatPath = path.join(__dirname, formatterPath, options.format);
   logger.debug(formatPath);
@@ -39,7 +39,7 @@ export default {
     let args = _.slice(cliArgs, 2, cliArgs.length);
     logger.debug('Directories to check: %o', dirs);
     logger.debug('Args %o', args);
-    _.each(args, function(item){
+    _.each(args, function (item) {
       if (!keys[item] && !formats[item]) {
         logger.debug('Pushing item: %s', item);
         arr.push(item);

--- a/src/arg-parser.js
+++ b/src/arg-parser.js
@@ -24,7 +24,7 @@ const formats = {
   'simple-detail': true
 };
 
-const getPath = function getPath(options) {
+function getPath(options) {
   logger.debug('GetPath: %s', options.format);
   const formatPath = path.join(__dirname, formatterPath, options.format);
   logger.debug(formatPath);

--- a/src/eslint/cli.js
+++ b/src/eslint/cli.js
@@ -6,7 +6,7 @@ import settings from '../settings';
 const logger = Logger('eslint-cli');
 logger.debug('Loaded');
 
-export default function eslintCli(args, options){
+export default function eslintCli(args, options) {
   logger.debug('eslint: %o', args.join(' '));
   const result = spawnSync(settings.eslintPath, args, _.merge({ stdio: 'inherit' }, options));
   logger.debug(result);

--- a/src/eslint/help.js
+++ b/src/eslint/help.js
@@ -8,11 +8,11 @@ logger.debug('Loaded');
 
 const namedOption = /^--/;
 
-function parseNo(option, str){
-  if(!str) return;
+function parseNo(option, str) {
+  if (!str) return;
 
   let cmd = str.replace('--', '');
-  if(/no-/.test(cmd)){
+  if (/no-/.test(cmd)) {
     logger.debug('Parsing no option', str);
     cmd = cmd.replace('no-', '');
     option.default = 'true';
@@ -21,7 +21,7 @@ function parseNo(option, str){
   return option;
 }
 
-function parseDouble(arr){
+function parseDouble(arr) {
   let description = _.without(arr.slice(2),'').join(' ');
   return {
     option: arr[0].replace('--', ''),
@@ -31,9 +31,9 @@ function parseDouble(arr){
   };
 }
 
-function parseRegular(arr){
+function parseRegular(arr) {
   logger.debug('Parsing %s', arr[0]);
-  if(!arr[0]){
+  if (!arr[0]) {
     return;
   }
   let optionText = arr[0];
@@ -46,29 +46,29 @@ function parseRegular(arr){
   let helpText = _.without(arr, optionText, type, '');
 
   let description = helpText.join(' ');
-  if(description){
+  if (description) {
     option.description = description;
   }
   return option;
 }
 
-function parseAlias(arr){
+function parseAlias(arr) {
   let alias = arr[0];
   logger.debug('Alias found: %s', alias);
   let option = parseRegular(_.without(arr, alias));
 
-  if(alias){
+  if (alias) {
     option.alias = alias.replace('-','');
   }
   return option;
 }
 
-function createOption(arr){
+function createOption(arr) {
   let option;
 
-  if(namedOption.test(arr[0]) && namedOption.test(arr[1])){ // no alias defaulted boolean
+  if (namedOption.test(arr[0]) && namedOption.test(arr[1])) { // no alias defaulted boolean
     option = parseDouble(arr);
-  } else if(namedOption.test(arr[0]) && !namedOption.test(arr[1])){ // just a no alias
+  } else if (namedOption.test(arr[0]) && !namedOption.test(arr[1])) { // just a no alias
     option = parseRegular(arr);
   } else {// aliased or other
     option = parseAlias(arr);
@@ -77,19 +77,19 @@ function createOption(arr){
   return isEmpty ? undefined : option;
 }
 
-function parseHelp(helpText){
+function parseHelp(helpText) {
   let helpArr = helpText.split('\n');
   let newArr = [];
   let previousLine = [];
-  _.each(helpArr, function(row, index){
-    if(index <= 2){
+  _.each(helpArr, function (row, index) {
+    if (index <= 2) {
       return;
     }
     let str = row.replace(',', '');
     let arr = str.trim().split(' ');
-    if(str.indexOf('-') >= 0 && previousLine[0] !== ''){
+    if (str.indexOf('-') >= 0 && previousLine[0] !== '') {
       let option = createOption(arr);
-      if(option && option.option !== 'format' && option.option !== 'help'){
+      if (option && option.option !== 'format' && option.option !== 'help') {
         newArr.push(option);
       }
     }
@@ -99,10 +99,10 @@ function parseHelp(helpText){
   return newArr;
 }
 
-export default function eslintHelp(){
+export default function eslintHelp() {
   logger.debug('Executing help');
   const result = eslint(['--help'], { stdio: [ process.stdin, null, process.stderr] });
-  if(!result.message){
+  if (!result.message) {
     throw new Error('Help text not received from Eslint.');
   }
   const eslintOptions = parseHelp(result.message);

--- a/src/executor.js
+++ b/src/executor.js
@@ -8,7 +8,7 @@ export default {
   spawnSync: (cmd, args, childOptions) => {
     logger.debug(cmd, args);
     const child = spawnSync(cmd, args, childOptions);
-    if(child.error){
+    if (child.error) {
       logger.debug('Critical error occurred.');
       throw new Error(child.stderr.toString());
     }

--- a/src/formatters/helpers/error-warning.js
+++ b/src/formatters/helpers/error-warning.js
@@ -1,6 +1,6 @@
 import { red, yellow, white } from 'chalk';
 
-export default function errorWarning(result){
+export default function errorWarning(result) {
   return result.errorCount || result.warningCount ?
     `${red(result.errorCount)}/${yellow(result.warningCount)} ${white(result.filePath)}` :
     `${red(result.messages.length)} ${white(result.filePath)}`;

--- a/src/formatters/helpers/success.js
+++ b/src/formatters/helpers/success.js
@@ -6,7 +6,7 @@ import Logger from '../../logger';
 const logger = Logger('success-formatter');
 logger.debug('loaded');
 
-export default function successHelper(result){
+export default function successHelper(result) {
   logger.debug(result);
   return `${chalk.green(c.check)} ${chalk.white(result.filePath)}`;
 };

--- a/src/formatters/simple-detail.js
+++ b/src/formatters/simple-detail.js
@@ -62,14 +62,14 @@ function simpleDetail(results) {
     }).join(c.endLine) + c.endLine + c.endLine;
   });
 
-  if(totalErrors) {
+  if (totalErrors) {
     output += chalk.red(`${c.x} ${totalErrors} ${pluralize('error', totalErrors)} `);
   }
   if (totalWarnings) {
     output += chalk.yellow(`${c.ex} ${totalWarnings} ${pluralize('warning', totalWarnings)} `);
   }
 
-  if(results.length > 0 || !results.length) {
+  if (results.length > 0 || !results.length) {
     cleanMsg = chalk.green(`${c.check} Clean`) + ` ${messageTime}`;
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ logger.debug(`Eslint-Watch: ${pkg.version}`);
 let exitCode;
 const args = process.argv;
 
-function runLint(args, options){
+function runLint(args, options) {
   logger.debug(args);
   const result = eslintCli(args, options);
   logger.debug('lint completed. Exit Code: %o', result.exitCode);
@@ -26,21 +26,21 @@ function runLint(args, options){
   logger.log(result.message);
 }
 
-function keyListener(args, options){
+function keyListener(args, options) {
   let stdin = process.stdin;
-  if(!stdin.setRawMode){
+  if (!stdin.setRawMode) {
     logger.debug('Process might be wrapped exiting keybinding');
     return;
   }
   keypress(stdin);
-  stdin.on('keypress', function keyPressListener(ch, key){
+  stdin.on('keypress', function keyPressListener(ch, key) {
     logger.debug('%s was pressed', key ? key.name : ch);
-    if(key && key.name === 'return'){
+    if (key && key.name === 'return') {
       logger.debug('relinting...');
       logger.debug(options);
       runLint(args, options);
     }
-    if(key && key.ctrl && key.name === 'c') {
+    if (key && key.ctrl && key.name === 'c') {
       process.exit();
     }
   });
@@ -52,7 +52,7 @@ logger.debug('Arguments passed: %o', args);
 const parsedOptions = helpOptions.parse(args);
 settings.cliOptions = parsedOptions;
 
-if(parsedOptions.eswVersion){
+if (parsedOptions.eswVersion) {
   logger.log(pkg.version);
 } else {
   logger.debug('Parsing args');

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,6 +1,6 @@
 import debug from 'debug';
 
-export default function createLogger(thing){
+export default function createLogger(thing) {
   return {
     log: console.log,
     error: console.error,

--- a/src/options.js
+++ b/src/options.js
@@ -42,7 +42,7 @@ const myOptions = [{
 }, {
   option: 'esw-version',
   type: 'Boolean',
-  description: "Prints Eslint-Watch's Version"
+  description: 'Prints Eslint-Watch\'s Version'
 }];
 
 const eslintOptions = getOptions();

--- a/src/settings.js
+++ b/src/settings.js
@@ -7,7 +7,7 @@ import fs from 'fs';
 const logger = Logger('internal-settings');
 const platform = os.platform();
 
-const eslintPath = (function loadEslintPath(){
+const eslintPath = (function loadEslintPath() {
   const cmd = platform === 'win32' ? '.cmd' : '';
   let eslintPath;
   try {
@@ -30,7 +30,7 @@ const eslintPath = (function loadEslintPath(){
 const settings = {
   eslintPath,
   platform,
-  isWindows: platform === 'win32',
+  isWindows: platform === 'win32'
 };
 
 logger.debug(settings);

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -28,9 +28,9 @@ const cliOptionMap = {
   cacheFile: 'cacheLocation'
 };
 
-function filterWarnings(results){
+function filterWarnings(results) {
   return _.reduce(results, (curr, result) =>{
-    if(result.warningCount){
+    if (result.warningCount) {
       let newResult = _.omit(result, 'messages');
       newResult.messages = _.find(result.messages, (m) => m.severity > 1);
       curr.push(newResult);
@@ -46,7 +46,7 @@ function filterWarnings(results){
 export default function watcher(options) {
   let cliOptions = _(options)
     .pick(cliOptionProperties)
-    .reduce(function(result, value, key){
+    .reduce(function (result, value, key) {
       key = cliOptionMap[key] || key;
       result[key] = value;
       return result;

--- a/tests/arg-parser-spec.js
+++ b/tests/arg-parser-spec.js
@@ -8,34 +8,34 @@ describe('arg-parser', function () {
     options = { '_': [] };
   });
 
-  it('appends the path at the end of parsing', function(){
+  it('appends the path at the end of parsing', function () {
     let args = ['/bin/esw', 'cmd', 'cool'];
     let arr = parser.parse(args, options);
     expect(arr).to.eql(['cool', './']);
   });
 
-  describe('defaults',function(){
-    it('should remove the first argument',function(){
+  describe('defaults',function () {
+    it('should remove the first argument',function () {
       let args = ['node', 'cmd', 'some/long/path'];
       let arr = parser.parse(args, options);
       expect(arr).to.not.include('node');
     });
 
-    it('should remove the second command',function(){
+    it('should remove the second command',function () {
       let args = ['/path/to/node','/bin/esw', '/something/else'];
       let arr = parser.parse(args, options);
       expect(arr).to.not.include('/bin/esw');
     });
 
-    it('removes the first two arguments', function(){
+    it('removes the first two arguments', function () {
       let args = ['/path/to/node', 'node', 'nodish'];
       let arr = parser.parse(args, options);
       expect(arr).to.eql(['nodish', './']);
     });
   });
 
-  describe('watch', function(){
-    it('parses for -w', function(){
+  describe('watch', function () {
+    it('parses for -w', function () {
       let args = ['node', 'some/long/path/to/prog', '-w'];
       let arr = parser.parse(args, options);
       expect(arr).to.not.contain('-w');
@@ -48,7 +48,7 @@ describe('arg-parser', function () {
       expect(arr).to.not.contain(watch);
     });
 
-    it('parses for --full-lint', function(){
+    it('parses for --full-lint', function () {
       const lint = '--changed';
       const args = ['node', 'some/long/path', lint];
       const arr = parser.parse(args, options);

--- a/tests/eslint/help-spec.js
+++ b/tests/eslint/help-spec.js
@@ -1,7 +1,7 @@
 let proxy = require('proxyquire');
 let _ = require('lodash');
 
-describe('eslint/help', function(){
+describe('eslint/help', function () {
   let title = 'title with options';
   let optionsTxt = 'Options:';
   let helpTxt = '--help      This has no alias or type';
@@ -13,13 +13,15 @@ describe('eslint/help', function(){
   let msg;
   let help;
 
-  before(function(){
+  before(function () {
     help = proxy('../../src/eslint/help', {
-      './cli': function(){ return { code: 0, message: msg }; }
+      './cli': function () {
+        return { code: 0, message: msg };
+      }
     });
   });
 
-  beforeEach(function(){
+  beforeEach(function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
@@ -29,130 +31,130 @@ describe('eslint/help', function(){
       noType + '\n';
   });
 
-  it('has an alias if one is provided', function(){
+  it('has an alias if one is provided', function () {
     const options = help();
     let option = options[0];
     expect(option.alias).to.equal('c');
   });
 
-  it('does not have an alias if not provided', function(){
+  it('does not have an alias if not provided', function () {
     const options = help();
     let option = options[1];
     expect(option.alias).to.equal(undefined);
   });
 
-  it('has a type', function(){
+  it('has a type', function () {
     const options = help();
     let option = options[0];
     expect(option.type).to.equal('Boolean');
   });
 
-  it('has a full description', function(){
+  it('has a full description', function () {
     const options = help();
     let option = options[0];
     expect(option.description).to.equal('Goes Cluck');
   });
 
-  it('filters out help', function(){
+  it('filters out help', function () {
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.notEqual(option.option, 'help');
     });
   });
 
-  it('filters out format', function(){
+  it('filters out format', function () {
     msg += '-f --format String     Stringify' + '\n';
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.notEqual(option.option, 'format');
     });
   });
 
-  it("doesn't set an option as undefined", function(){
+  it('doesn\'t set an option as undefined', function () {
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.ok(option.option);
     });
   });
 
-  it("doesn't set an alias as undefined", function(){
+  it('doesn\'t set an alias as undefined', function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
       helpTxt + '\n' +
       cluck + '\n';
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.ok(option.alias);
     });
   });
 
-  it("doesn't set a type as undefined", function(){
+  it('doesn\'t set a type as undefined', function () {
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.ok(option.type);
     });
   });
 
-  it("doesn't set a description as undefined", function(){
+  it('doesn\'t set a description as undefined', function () {
     const options = help();
-    _.each(options, function(option){
+    _.each(options, function (option) {
       assert.ok(option.description);
     });
   });
 
-  it("sets the default to Boolean if type isn't provided", function(){
+  it('sets the default to Boolean if type isn\'t provided', function () {
     const options = help();
     let option = options[2];
     expect(option.type).to.equal('Boolean');
   });
 
-  it("shouldn't throw exceptions", function(){
+  it('shouldn\'t throw exceptions', function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
       helpTxt + '\n' +
       '\n' +
-      'HEADING:\n'+
+      'HEADING:\n' +
       cluck + '\n';
-    expect(function (){
+    expect(function () {
       help();
     }).to.not.throw();
   });
 
-  it('filters out no from help options', function() {
+  it('filters out no from help options', function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
       helpTxt + '\n' +
       '\n' +
-      'HEADING:\n'+
+      'HEADING:\n' +
       noColor + '\n';
     const options = help();
     let colorOption = options[0];
     expect(colorOption.option).to.equal('color');
   });
 
-  it('defaults no options to true', function(){
+  it('defaults no options to true', function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
       helpTxt + '\n' +
       '\n' +
-      'HEADING:\n'+
+      'HEADING:\n' +
       noColor + '\n';
     const options = help();
     let colorOption = options[0];
     expect(colorOption.default).to.equal('true');
   });
 
-  it('can parse doubled option options', function(){
+  it('can parse doubled option options', function () {
     msg = title + '\n' +
       '\n' +
       optionsTxt + '\n' +
       helpTxt + '\n' +
       '\n' +
-      'HEADING:\n'+
+      'HEADING:\n' +
       doubleExample + '\n';
     const options = help();
     let colorOption = options[0];

--- a/tests/formatters/helpers/error-waning-spec.js
+++ b/tests/formatters/helpers/error-waning-spec.js
@@ -1,9 +1,9 @@
 let formatter = require('../../../src/formatters/helpers/error-warning');
 let chalk = require('chalk');
 
-describe('error-warning-helper', function(){
+describe('error-warning-helper', function () {
   let sandbox;
-  beforeEach(function (){
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     let format = {
       open: '',
@@ -15,23 +15,23 @@ describe('error-warning-helper', function(){
     sandbox.stub(chalk.styles, 'white', format);
   });
 
-  afterEach(function(){
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('prints error count if errorCount exists', function(){
+  it('prints error count if errorCount exists', function () {
     let object = { errorCount: 4, warningCount: 0, filePath: '/some/file/path' };
     let result = formatter(object);
     expect(result).to.equal('4/0 /some/file/path');
   });
 
-  it('prints warning count if warningCount exists', function(){
+  it('prints warning count if warningCount exists', function () {
     let object = { errorCount: 0, warningCount: 4, filePath: '/some/file/path' };
     let result = formatter(object);
     expect(result).to.equal('0/4 /some/file/path');
   });
 
-  it('prints just errors when there are messages', function(){
+  it('prints just errors when there are messages', function () {
     let object = { messages: ['hello', 'two'], filePath: '/some/file/path' };
     let result = formatter(object);
     expect(result).to.equal('2 /some/file/path');

--- a/tests/formatters/helpers/success-spec.js
+++ b/tests/formatters/helpers/success-spec.js
@@ -1,9 +1,9 @@
 let formatter = require('../../../src/formatters/helpers/success');
 let chalk = require('chalk');
 
-describe('success-helper', function(){
+describe('success-helper', function () {
   let sandbox;
-  beforeEach(function (){
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     let format = {
       open: '',
@@ -14,11 +14,11 @@ describe('success-helper', function(){
     sandbox.stub(chalk.styles, 'white', format);
   });
 
-  afterEach(function(){
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('places a checkmark and the path', function(){
+  it('places a checkmark and the path', function () {
     let object = { filePath: '/some/file/path' };
     let result = formatter(object);
     expect(result).to.equal('✓ /some/file/path');

--- a/tests/formatters/simple-detail-spec.js
+++ b/tests/formatters/simple-detail-spec.js
@@ -2,13 +2,13 @@ let formatter = require('../../src/formatters/simple-detail');
 let chalk = require('chalk');
 let icons = require('../../src/formatters/helpers/characters');
 
-describe('simple-detail', function(){
+describe('simple-detail', function () {
   let sandbox;
   let errorResult;
   let warningResult;
   let filePath;
 
-  beforeEach(function (){
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     let format = {
       open: '',
@@ -47,62 +47,62 @@ describe('simple-detail', function(){
     };
   });
 
-  afterEach(function(){
+  afterEach(function () {
     sandbox.restore();
   });
 
-  describe('clean', function(){
+  describe('clean', function () {
     // Possible this test might fail. haha oh well...
     // Works for now.
-    it('prints out a checkmark with the date', function(){
+    it('prints out a checkmark with the date', function () {
       let time = new Date().toLocaleTimeString();
       let result = formatter([]);
       expect(result).to.equal(icons.check + ' Clean ' + '(' + time + ')');
     });
   });
 
-  describe('errors', function(){
+  describe('errors', function () {
     // can break sometimes
-    it('prints out errors if there are any', function(){
+    it('prints out errors if there are any', function () {
       let time = new Date().toLocaleTimeString();
       let result = formatter([errorResult]);
       expect(result).to.equal(filePath + ' (1/0)\n  ' + icons.x + '  0:0  broken something or other  broken-things\n\n' + icons.x + ' 1 error (' + time + ')\n');
     });
 
-    it('prints out errors if there are multiple', function(){
+    it('prints out errors if there are multiple', function () {
       let result = formatter([errorResult, errorResult]);
       expect(result).to.includes('errors');
     });
   });
 
-  describe('warnings', function(){
+  describe('warnings', function () {
     // can break
-    it('prints out any warnings if there are any', function(){
+    it('prints out any warnings if there are any', function () {
       let time = new Date().toLocaleTimeString();
       let result = formatter([warningResult]);
       expect(result).to.equal(filePath + ' (0/1)\n  ' + icons.ex + '  1:2  you should do this  advised\n\n' + icons.ex + ' 1 warning (' + time + ')\n');
     });
 
-    it('prints out warnings if there are multiple', function(){
+    it('prints out warnings if there are multiple', function () {
       let result = formatter([warningResult, warningResult]);
       expect(result).to.include('warnings');
     });
   });
 
-  describe('errors/warnings', function(){
-    it('prints out warnings and errors', function(){
+  describe('errors/warnings', function () {
+    it('prints out warnings and errors', function () {
       let result = formatter([errorResult, warningResult]);
       expect(result).to.include('1 error');
       expect(result).to.include('1 warning');
     });
 
-    it('prints out both errors and warnings', function(){
+    it('prints out both errors and warnings', function () {
       let result = formatter([errorResult, errorResult, warningResult, warningResult]);
       expect(result).to.include('2 warnings');
       expect(result).to.include('2 errors');
     });
 
-    it('prints out both errors and warnings for one file', function(){
+    it('prints out both errors and warnings for one file', function () {
       let results = [{
         errorCount: 1,
         warningCount: 1,

--- a/tests/formatters/simple-spec.js
+++ b/tests/formatters/simple-spec.js
@@ -1,9 +1,9 @@
 let formatter = require('../../src/formatters/simple');
 let chalk = require('chalk');
 
-describe('simple formatter', function(){
+describe('simple formatter', function () {
   let sandbox;
-  beforeEach(function (){
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     let format = {
       open: '',
@@ -15,17 +15,17 @@ describe('simple formatter', function(){
     sandbox.stub(chalk.styles, 'white', format);
   });
 
-  afterEach(function(){
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('prints the error count', function(){
+  it('prints the error count', function () {
     let object = { errorCount: 4, warningCount: 0, filePath: '/some/file/path' };
     let result = formatter([object]);
     expect(result).to.equal('4/0 /some/file/path\n');
   });
 
-  it('prints nothing if there are no errors or warnings', function(){
+  it('prints nothing if there are no errors or warnings', function () {
     let result = formatter([{ errorCount: 0, warningCount: 0 }]);
     expect(result).to.equal('');
   });

--- a/tests/formatters/simple-success-spec.js
+++ b/tests/formatters/simple-success-spec.js
@@ -1,9 +1,9 @@
 let formatter = require('../../src/formatters/simple-success');
 let chalk = require('chalk');
 
-describe('simple-success', function(){
+describe('simple-success', function () {
   let sandbox;
-  beforeEach(function (){
+  beforeEach(function () {
     sandbox = sinon.sandbox.create();
     let format = {
       open: '',
@@ -16,29 +16,29 @@ describe('simple-success', function(){
     sandbox.stub(chalk.styles, 'white', format);
   });
 
-  afterEach(function(){
+  afterEach(function () {
     sandbox.restore();
   });
 
-  it('prints the success message', function(){
+  it('prints the success message', function () {
     let object = { errorCount: 0, warningCount: 0, filePath: '/some/file/path' };
     let result = formatter([object]);
     expect(result).to.equal('✓ /some/file/path\n');
   });
 
-  it('prints the error message if there are errors', function(){
+  it('prints the error message if there are errors', function () {
     let results = { errorCount: 2, warningCount: 0, filePath: '/some/file/path' };
     let result = formatter([results]);
     expect(result).to.equal('2/0 /some/file/path\n');
   });
 
-  it('prints the warning message if there are warnings', function(){
+  it('prints the warning message if there are warnings', function () {
     let results = { errorCount: 0, warningCount: 1, filePath: '/some/file/path' };
     let result = formatter([results]);
     expect(result).to.equal('0/1 /some/file/path\n');
   });
 
-  it('prints the both messages if there are warnings and errors', function(){
+  it('prints the both messages if there are warnings and errors', function () {
     let results = { errorCount: 1, warningCount: 1, filePath: '/some/file/path' };
     let result = formatter([results]);
     expect(result).to.equal('1/1 /some/file/path\n');

--- a/tests/integration/integration-spec.js
+++ b/tests/integration/integration-spec.js
@@ -6,16 +6,16 @@ import pkg from '../../package';
 const eswPath = path.join(__dirname, '../../bin/esw');
 const testFiles = path.join(__dirname, 'test-files');
 
-describe('integration', function(){
+describe('integration', function () {
   let esw;
-  before(function(){
-    esw = function(cmd){
+  before(function () {
+    esw = function (cmd) {
       let result = {};
-      try{
+      try {
         let command = 'node "' + eswPath + '" ' + cmd;
         result.message = child.execSync(command).toString();
         result.error = false;
-      } catch(e){
+      } catch (e) {
         result.error = true;
         result.message = e.stdout.toString();
         result.cmd = e.cmd;
@@ -24,71 +24,71 @@ describe('integration', function(){
     };
   });
 
-  describe('general', function(){
-    it('reports any kind of help information', function(){
+  describe('general', function () {
+    it('reports any kind of help information', function () {
       let output = esw('--help');
       expect(output.error).to.be.false;
       expect(output.message).to.have.string('esw [options]');
     });
 
-    it("cache command doesn't show help", function(){
+    it('cache command doesn\'t show help', function () {
       let output = esw('--cache --cache-location node_modules/esw.cache');
       expect(output.error).to.be.false;
       expect(output.message).to.not.have.string('Options');
     });
 
-    it("doesn't throw when a no option is used", function(){
+    it('doesn\'t throw when a no option is used', function () {
       let output = esw('--no-color');
       expect(output.error).to.be.false;
     });
   });
 
-  describe('help', function(){
-    it('has -w and --watch', function() {
+  describe('help', function () {
+    it('has -w and --watch', function () {
       let output = esw('--help');
       expect(output.error).to.be.false;
       expect(output.message).to.have.string('-w');
       expect(output.message).to.have.string('--watch');
     });
 
-    it('has simple-detail as default format', function(){
+    it('has simple-detail as default format', function () {
       let output = esw('--help');
       expect(output.error).to.be.false;
       expect(output.message).to.have.string('default: simple-detail');
     });
   });
 
-  describe('watching', function(){
-    beforeEach(function(){
+  describe('watching', function () {
+    beforeEach(function () {
 
     });
 
-    afterEach(function(){
+    afterEach(function () {
 
     });
   });
 
-  describe('linting', function(){
-    it('finds 5 issues in test-files', function(){
+  describe('linting', function () {
+    it('finds 5 issues in test-files', function () {
       let output = esw(`--no-ignore "${testFiles}"`);
       expect(output.error).to.be.true;
       expect(output.message).to.have.string('5 errors');
     });
 
-    it('finds 2 warnings', function(){
+    it('finds 2 warnings', function () {
       let output = esw(`--no-ignore "${testFiles}"`);
       expect(output.error).to.be.true;
       expect(output.message).to.have.string('2 warnings');
     });
 
-    it("doesn't find warnings with --quiet", function(){
+    it('doesn\'t find warnings with --quiet', function () {
       let output = esw('--quiet --no-ignore "' + testFiles + '"');
       expect(output.error).to.be.true;
       expect(output.message).to.not.have.string('2 warnings');
     });
   });
 
-  describe('version', function(){
+  describe('version', function () {
     it('prints out eslint-watch version with --esw-version', () =>{
       const output = esw('--esw-version');
       expect(output.error).to.be.false;

--- a/tests/integration/integration-spec.js
+++ b/tests/integration/integration-spec.js
@@ -72,7 +72,7 @@ describe('integration', function () {
     it('finds 5 issues in test-files', function () {
       let output = esw(`--no-ignore "${testFiles}"`);
       expect(output.error).to.be.true;
-      expect(output.message).to.have.string('5 errors');
+      expect(output.message).to.have.string('7 errors');
     });
 
     it('finds 2 warnings', function () {

--- a/tests/watcher-spec.js
+++ b/tests/watcher-spec.js
@@ -9,27 +9,27 @@ describe('Watcher', function () {
   let path;
   let isIgnored;
 
-  beforeEach(function(){
+  beforeEach(function () {
     onSpy = sinon.spy();
     errorSpy = sinon.spy();
     path = '';
     isIgnored = false;
-    let cliEngine = function(){
+    let cliEngine = function () {
       return {
         options: {
           extensions: ['.js']
         },
-        isPathIgnored: function() {
+        isPathIgnored: function () {
           return isIgnored;
         },
-        executeOnFiles: function() {
+        executeOnFiles: function () {
           return {
             results: [{ errorCount: 0, warningCount: 0 }]
           };
         }
       };
     };
-    on = function(event, cllbk){
+    on = function (event, cllbk) {
       onSpy(event);
       cllbk(path);
       return {
@@ -37,40 +37,40 @@ describe('Watcher', function () {
       };
     };
     watcher = proxy('../src/watcher',{
-      './logger': function(){
+      './logger': function () {
         return {
-          log: function(){},
-          debug: function(){}
+          log: function () {},
+          debug: function () {}
         };
       },
       'chokidar': {
-        watch: function(options){
+        watch: function (options) {
           watcherOptions = options;
           return {
             on: on
           };
-        },
+        }
       },
       'eslint': {
         CLIEngine: cliEngine
       },
-      './formatters/simple-detail': function(){},
-      './formatters/helpers/success': function(){}
+      './formatters/simple-detail': function () {},
+      './formatters/helpers/success': function () {}
     });
   });
 
-  it('calls the on event', function(){
+  it('calls the on event', function () {
     watcher({ _: [], format: 'simple-detail' });
     expect(onSpy.called).to.be.true;
   });
 
-  it('watches the directories under _ attribute', function() {
+  it('watches the directories under _ attribute', function () {
     let arr = ['hello'];
     watcher({ _: arr, format: 'simple-detail' });
     expect(watcherOptions).to.equal(arr);
   });
 
-  it('calls the on changed event', function() {
+  it('calls the on changed event', function () {
     watcher({ _: [], format: 'simple-detail' });
     expect(onSpy).to.have.been.calledWith('change');
   });


### PR DESCRIPTION
### What was the problem/Ticket Number

While evaluating this project / attempting to add some features / make some fixes, I noticed a high degree of variance in fairly simple eslintable code style.

### How does this solve the problem?

Adding a few rules (intention was to choose the rules which were most consistent with the current codebase, not set my own rules), and running `eslint --fix` was able to resolve

### How to duplicate the issue

  1. Static review of the code should show the issue.
  2. Running `npm run lint` should show the same number of warnings / errors before and after this PR.
