### PR TITLE
Add message when linting is restarted

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -36,6 +36,7 @@ function keyListener(args, options){
   stdin.on('keypress', function keyPressListener(ch, key){
     logger.debug('%s was pressed', key ? key.name : ch);
     if(key && key.name === 'return'){
+      logger.log('Relinting at user request <return>');
       logger.debug('relinting...');
       logger.debug(options);
       runLint(args, options);


### PR DESCRIPTION
### What was the problem/Ticket Number
https://github.com/rizowski/eslint-watch/issues/122 Subpoint 2

### How does this solve the problem?
Adds a message to logger when linting is restarted 

### How to duplicate the issue

  1. Hit return with an active watch.
  2. Enjoy the new message confirming the relint.
