### PR TITLE
Refactor child process to CPS

### DIFF
--- a/src/eslint/cli.js
+++ b/src/eslint/cli.js
@@ -1,14 +1,12 @@
 import _ from 'lodash';
-import { spawnSync } from '../executor';
+import { spawn } from '../executor';
 import Logger from '../logger';
 import settings from '../settings';
 
 const logger = Logger('eslint-cli');
 logger.debug('Loaded');
 
-export default function eslintCli(args, options){
+export default function eslintCli(args, options, cb) {
   logger.debug('eslint: %o', args.join(' '));
-  const result = spawnSync(settings.eslintPath, args, _.merge({ stdio: 'inherit' }, options));
-  logger.debug(result);
-  return result;
+  spawn(settings.eslintPath, args, options, cb);
 };

--- a/src/eslint/help.js
+++ b/src/eslint/help.js
@@ -99,12 +99,13 @@ function parseHelp(helpText){
   return newArr;
 }
 
-export default function eslintHelp(){
+export default function eslintHelp(cb) {
   logger.debug('Executing help');
-  const result = eslint(['--help'], { stdio: [ process.stdin, null, process.stderr] });
-  if(!result.message){
-    throw new Error('Help text not received from Eslint.');
-  }
-  const eslintOptions = parseHelp(result.message);
-  return eslintOptions;
+  eslint(['--help'], { stdio: [ process.stdin, null, process.stderr] }, (result) => {
+    if(!result.message){
+      throw new Error('Help text not received from Eslint.');
+    }
+    const eslintOptions = parseHelp(result.message);
+    cb(eslintOptions);
+  });
 };

--- a/src/options.js
+++ b/src/options.js
@@ -45,8 +45,10 @@ const myOptions = [{
   description: "Prints Eslint-Watch's Version"
 }];
 
-const eslintOptions = getOptions();
-const newOptions = _.union(myOptions, eslintOptions);
-settings.options = newOptions;
-
-export default optionator(settings);
+export default function parseOptions(options, cb) {
+  getOptions(function (eslintOptions) {
+    const newOptions = _.union(myOptions, eslintOptions);
+    settings.options = newOptions;
+    cb(optionator(settings).parse(options))
+  });
+}


### PR DESCRIPTION
### What was the problem/Ticket Number
https://github.com/rizowski/eslint-watch/issues/122 Point 4


### How does this solve the problem?
This aids in responsivity by removing the blocking (sync) call to spawn, re architecting a bit of the code paths to observe CPS format (callbacks).

By being non-blocking, the process can immediately quit on keyboard interrupt.

(I understand tests are broken, this is a WIP until I get feedback).

### How to duplicate the issue

  1. Start a watch
  2. <return> several times
  3. Ctrl + C  -- should instantly quit
