### PR TITLE
Fix: #130 / TypeError: Cannot read property 'length' of undefined

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -32,7 +32,7 @@ function filterWarnings(results) {
   return _.reduce(results, (curr, result) =>{
     if (result.warningCount) {
       let newResult = _.omit(result, 'messages');
-      newResult.messages = _.find(result.messages, (m) => m.severity > 1);
+      newResult.messages = (result.messages || []).filter((m) => m.severity > 1);
       curr.push(newResult);
       return curr;
     }


### PR DESCRIPTION
### What was the problem/Ticket Number
#130 #119 

### How does this solve the problem?
It replaces `_.find` used for filtering with `Array.prototype.filter`

### How to duplicate the issue

  1. run watcher with --quiet
  2. update a file (for example 1 error -> clean)
  3. messages would be reduced from an `array` to `object/undefined` instead of a filtered `array`
  4. filtered *array*`.length`access will break further down the line in `simpleDetail`

For more info see #130 