### PR TITLE
Using `console.clear()` to avoid special character in terminal with --clear flag

### DIFF
--- a/src/formatters/helpers/clear-terminal.js
+++ b/src/formatters/helpers/clear-terminal.js
@@ -1,3 +1,3 @@
 export default function clearTerminal() {
-  process.stdout.write('\x1Bc');
+  console.clear();
 }


### PR DESCRIPTION
Switch usage of `process.stdout.write('\x1Bc');` with `console.clear();`

### What was the problem/Ticket Number
There is some issue with special character if `--clear` is specified

![cleannotworking](https://user-images.githubusercontent.com/1384475/40366528-9dc64eb0-5dd7-11e8-8074-88dd062576a0.jpg)
![errornotworking](https://user-images.githubusercontent.com/1384475/40366529-9df76fb8-5dd7-11e8-86a4-b28f4bbc30df.jpg)


### How does this solve the problem?
Using `console.clear();` native method solves the issue

![cleanworking](https://user-images.githubusercontent.com/1384475/40366542-abeaaf5e-5dd7-11e8-9d5f-455785ae637f.jpg)
![errorworking](https://user-images.githubusercontent.com/1384475/40366543-ac14e95e-5dd7-11e8-857c-3025bfe575a4.jpg)


### How to duplicate the issue

  1. Pass `--clear` option
