### PR TITLE
Using `\u001B[2J\u001B[0;0f` to avoid special character in `Hyper` with --clear flag

### DIFF
--- a/src/formatters/helpers/clear-terminal.js
+++ b/src/formatters/helpers/clear-terminal.js
@@ -1,3 +1,3 @@
 export default function clearTerminal() {
-  process.stdout.write('\x1Bc');
+  process.stdout.write('\u001B[2J\u001B[0;0f');
 }

--- a/tests/unit/formatters/helpers/clear-terminal-spec.js
+++ b/tests/unit/formatters/helpers/clear-terminal-spec.js
@@ -16,6 +16,6 @@ describe('clear terminal', () => {
   it('calls process.stdout.write with the clear command', () => {
     clear();
 
-    expect(spy.firstCall.args[0]).to.equal('\u001bc');
+    expect(spy.firstCall.args[0]).to.equal('\u001B[2J\u001B[0;0f');
   });
 });


### PR DESCRIPTION
Using `\u001B[2J\u001B[0;0f` to avoid special character in `Hyper` with --clear flag

It works in every other terminal, tested 👍 

### What was the problem/Ticket Number
There is some issue with special character if `--clear` is specified

![cleannotworking](https://user-images.githubusercontent.com/1384475/40366528-9dc64eb0-5dd7-11e8-8074-88dd062576a0.jpg)
![errornotworking](https://user-images.githubusercontent.com/1384475/40366529-9df76fb8-5dd7-11e8-86a4-b28f4bbc30df.jpg)


### How does this solve the problem?
Using `\u001B[2J\u001B[0;0f` native method solves the issue.
The first code `\u001B[2J` instructs the terminal to clear itself, and the second one `\u001B[0;0f` forces the cursor back to position 0,0.

![cleanworking](https://user-images.githubusercontent.com/1384475/40366542-abeaaf5e-5dd7-11e8-9d5f-455785ae637f.jpg)
![errorworking](https://user-images.githubusercontent.com/1384475/40366543-ac14e95e-5dd7-11e8-857c-3025bfe575a4.jpg)


### How to duplicate the issue

  1. Pass `--clear` option
