### PR TITLE
Add rule to options

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -28,12 +28,14 @@ const cliOptionProperties = [
   'fix',
   'parserOptions',
   'global',
+  'rule',
 ];
 const cliOptionMap = {
   config: 'configFile',
   eslintrc: 'useEslintrc',
   ext: 'extensions',
   cacheFile: 'cacheLocation',
+  rule: 'rules',
 };
 
 function filterWarnings(results) {


### PR DESCRIPTION
### What was the problem/Ticket Number
Some rules need to be `off` in `watch mode`, like `prettier/prettier`. This should be checked in `lint` after `prettier --write`, but I think this should not be checked in `watch mode`. As a result, I will use command like `esw --ext .js --rule 'prettier/prettier: off' .`.

### How does this solve the problem?
Add `rule` to `options`.

### How to duplicate the issue

  1. Add `--rule` in command like `--rule 'prettier/prettier: off'`.
  2. Modify files.
