### PR TITLE
Fix rules option error

### DIFF
--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -103,7 +103,7 @@ export default {
 
         if (key === 'rule') {
           Object.keys(value).forEach((ruleKey) => {
-            acc.flags.push('--rule', `${ruleKey}: ${value[ruleKey]}`);
+            acc.flags.push('--rule', `${ruleKey}: ${JSON.stringify(value[ruleKey]).replace(/"/g, '')}`);
           });
 
           return acc;

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -78,11 +78,6 @@ export default {
         const options = opsor.parse(rawArgs, { slice: 0 });
         const dirs = options._;
 
-        Object.keys(options).forEach(key => {
-          if (options[key] instanceof Object)
-            options[key] = Object.keys(options[key]).map((optionKey) => `${optionKey}: ${options[key][optionKey]}`).join('');
-        });
-
         if (dirs.length === 0) {
           dirs.push(path.resolve('.'));
         }
@@ -103,6 +98,14 @@ export default {
         }
 
         if (key === '_') {
+          return acc;
+        }
+
+        if (key === 'rule') {
+          Object.keys(value).forEach((ruleKey) => {
+            acc.flags.push('--rule', `${ruleKey}: ${value[ruleKey]}`);
+          });
+
           return acc;
         }
 

--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -78,6 +78,11 @@ export default {
         const options = opsor.parse(rawArgs, { slice: 0 });
         const dirs = options._;
 
+        Object.keys(options).forEach(key => {
+          if (options[key] instanceof Object)
+            options[key] = Object.keys(options[key]).map((optionKey) => `${optionKey}: ${options[key][optionKey]}`).join('');
+        });
+
         if (dirs.length === 0) {
           dirs.push(path.resolve('.'));
         }

--- a/src/events/watch/index.js
+++ b/src/events/watch/index.js
@@ -34,6 +34,9 @@ export default {
         /* istanbul ignore next */
         .on('add', (dir) => logger.debug(`${dir} added.`))
         .on('change', async (path) => {
+          if (new RegExp(opts.cacheLocation || '.eslintcache').test(path))
+            return;
+
           logger.debug('Detected change:', path);
           const changed = opts.changed ? [path] : opts._;
 

--- a/src/events/watch/index.js
+++ b/src/events/watch/index.js
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import watch from './chokidar';
 import { createLogger } from '../../logger';
 import eslint from '../../eslint';
@@ -20,6 +22,7 @@ export default {
   listen(opts) {
     const watcher = watch.createWatcher(opts._, { ignored: opts.watchIgnore });
     const { flags, dirs } = cli.getCli(opts);
+    const cacheLocation = path.relative(process.cwd(), path.resolve(opts.cacheLocation || '.eslintcache'));
 
     key.listen(['enter'], async () => {
       await lint(opts, [...flags, ...dirs]);
@@ -33,12 +36,12 @@ export default {
         })
         /* istanbul ignore next */
         .on('add', (dir) => logger.debug(`${dir} added.`))
-        .on('change', async (path) => {
-          if (new RegExp(opts.cacheLocation || '.eslintcache').test(path))
+        .on('change', async (filePath) => {
+          if (cacheLocation === filePath)
             return;
 
-          logger.debug('Detected change:', path);
-          const changed = opts.changed ? [path] : opts._;
+          logger.debug('Detected change:', filePath);
+          const changed = opts.changed ? [filePath] : opts._;
 
           await lint(opts, [...flags, ...changed]);
         })

--- a/tests/unit/cli/options-spec.js
+++ b/tests/unit/cli/options-spec.js
@@ -119,5 +119,11 @@ describe('cli/options', () => {
         .to.be.an('array')
         .and.to.have.length(0);
     });
+
+    it('set rules to --rule', () => {
+      const result = options.getCli({ rule: { 'guard-for-in': 2, 'brace-style': [2, '1tbs'] } });
+
+      expect(result.flags).to.eql(['--rule', 'guard-for-in: 2', '--rule', 'brace-style: [2,1tbs]']);
+    });
   });
 });


### PR DESCRIPTION
### What was the problem/Ticket Number
1. I got this errors with using `esw --rule 'prettier/prettier: off'`:

```sh
  esw:eslint Executing [ '--cache', '--rule', { 'prettier/prettier': 'off' }, '--quiet', '--eslintrc', '--ignore', '--inline-config', '.' ] +0ms
  esw:eslint Error: Command failed: eslint --cache --rule [object Object] --quiet --eslintrc --ignore --inline-config .
  esw:eslint 2019-03-26T08:11:05.924Z eslint:cli CLI args: [ '--cache', '--rule', '[object Object]', '--quiet', '--eslintrc', '--ignore', '--inline-config', '.' ]
  esw:eslint Invalid value for option 'rule' - expected type Object, received value: [object Object].
```
2. The other problem is that `.eslintcache` will trigger `chokidar` changed event.

### How does this solve the problem?
1. Make rules options to be string.
2. Ignore `cacheLocation`.

### How to duplicate the issue

  1. Use `esw --rule 'prettier/prettier: off'`.
