### PR TITLE
Make the watcher respect cli --ext flag

### DIFF
--- a/src/cli/options.js
+++ b/src/cli/options.js
@@ -60,6 +60,15 @@ const defaultOptions = [
     description: 'Delay(ms) for watcher to wait to trigger re-lint',
     default: '300',
   },
+  {
+    heading: 'Basic configuration',
+  },
+  {
+    option: 'ext',
+    type: '[String]',
+    description: 'Specify JavaScript file extensions',
+    default: '.js',
+  },
 ];
 
 function areEqual(opt1, opt2) {

--- a/src/events/watch/index.js
+++ b/src/events/watch/index.js
@@ -41,6 +41,10 @@ export default {
           'change',
           debounce(async (filePath) => {
             if (cacheLocation === filePath) return;
+            if (!opts.ext.includes(path.extname(filePath))) {
+              logger.debug(`Watch: Skipping ${filePath}`);
+              return;
+            }
 
             logger.debug('Detected change:', filePath);
             const changed = opts.changed ? [filePath] : opts._;

--- a/tests/unit/cli/options-spec.js
+++ b/tests/unit/cli/options-spec.js
@@ -23,14 +23,17 @@ describe('cli/options', () => {
         `esw [options] [file.js ...] [dir ...]
 
         ESW Options:
-          -h, --help     Show help
-          -w, --watch    Enable file watch
-          --changed      Enables single file linting while watch is enabled
-          --clear        Clear terminal when running lint
-          -v, --version  Prints Eslint-Watch Version
-          --versions     Prints Eslint-Watch and Eslint Versions
+          -h, --help             Show help
+          -w, --watch            Enable file watch
+          --changed              Enables single file linting while watch is enabled
+          --clear                Clear terminal when running lint
+          -v, --version          Prints Eslint-Watch Version
+          --versions             Prints Eslint-Watch and Eslint Versions
           --watch-ignore RegExp  Regex string of folders to ignore when watching - default: /.git|node_modules|bower_components/
-          --watch-delay Int Delay(ms) for watcher to wait to trigger re-lint - default: 300`.replace(/\s+/g, ' ')
+          --watch-delay Int      Delay(ms) for watcher to wait to trigger re-lint - default: 300
+
+        Basic configuration:
+          --ext [String]         Specify JavaScript file extensions - default: .js`.replace(/\s+/g, ' ')
       );
     });
 
@@ -68,6 +71,7 @@ describe('cli/options', () => {
           watch: true,
           changed: true,
           clear: true,
+          ext: ['.js'],
           version: true,
           versions: true,
           watchIgnore: /node_modules|dist|build/,

--- a/tests/unit/events/watch-spec.js
+++ b/tests/unit/events/watch-spec.js
@@ -31,7 +31,7 @@ describe('events/watch', () => {
   });
 
   it('creates a watcher', () => {
-    const options = { _: ['./'] };
+    const options = { _: ['./'], ext: ['.js'] };
     watch.listen(options);
 
     expect(emitter.listeners('add')).to.have.length(1);
@@ -44,41 +44,58 @@ describe('events/watch', () => {
   });
 
   it('lints the directory when a change is detected', (done) => {
-    const opts = { _: ['./'] };
+    const opts = { _: ['./'], ext: ['.js'] };
     watch.listen(opts);
 
-    emitter.emit('change', './some/path');
+    emitter.emit('change', './some/path.js');
 
     setTimeout(() => {
       try {
         expect(lintStub.calledOnce).to.equal(true);
-        expect(lintStub.firstCall.args).to.eql([['./'], opts]);
+        expect(lintStub.firstCall.args).to.eql([['--ext', ['.js'], './'], opts]);
         done();
       } catch (error) {
         done(error);
       }
-    }, 100);
+    }, 0);
   });
 
   it('lints the changed path when --changed is provided and a change is detected', (done) => {
-    const opts = { _: ['./'], changed: true };
+    const opts = { _: ['./'], changed: true, ext: ['.js'] };
     watch.listen(opts);
 
-    emitter.emit('change', './some/path');
+    emitter.emit('change', './some/path.js');
 
     setTimeout(() => {
       try {
         expect(lintStub.calledOnce).to.equal(true);
-        expect(lintStub.firstCall.args).to.eql([['./some/path'], opts]);
+        expect(lintStub.firstCall.args).to.eql([['--ext', ['.js'], './some/path.js'], opts]);
         done();
       } catch (error) {
         done(error);
       }
-    }, 100);
+    }, 0);
+  });
+
+  it('does not lint non js files', (done) => {
+    const opts = { _: ['./'], changed: true, ext: ['.js'] };
+
+    watch.listen(opts);
+
+    emitter.emit('change', './some/path.py');
+
+    setTimeout(() => {
+      try {
+        expect(lintStub.called).to.equal(false);
+        done();
+      } catch (error) {
+        done(error);
+      }
+    }, 0);
   });
 
   it('runs an initial lint when the ready event is fired', (done) => {
-    const opts = { _: ['./'], changed: true };
+    const opts = { _: ['./'], changed: true, ext: ['.js'] };
     watch.listen(opts);
 
     emitter.emit('ready');
@@ -86,11 +103,11 @@ describe('events/watch', () => {
     setTimeout(() => {
       try {
         expect(lintStub.calledOnce).to.equal(true);
-        expect(lintStub.firstCall.args).to.eql([['./'], opts]);
+        expect(lintStub.firstCall.args).to.eql([['--ext', ['.js'], './'], opts]);
         done();
       } catch (error) {
         done(error);
       }
-    }, 100);
+    }, 0);
   });
 });


### PR DESCRIPTION
Fixes #160 

Overrides the default for `--ext` but makes it so that the watcher can always assume the default from the cli.