### PR TITLE
Enable error message that `eslint` is not installed

### DIFF
--- a/src/eslint/index.js
+++ b/src/eslint/index.js
@@ -24,7 +24,7 @@ const eslint = {
     } catch (error) {
       logger.debug(error);
 
-      if (error.errno === 'ENOENT' && error.path === 'eslint') {
+      if (error.code === 'ENOENT' && error.path === 'eslint') {
         throw new Error("Error: Eslint was not found either globally or locally.\nRun 'npm i -g eslint' or 'npm i -D eslint' to resolve the issue.");
       }
 


### PR DESCRIPTION
### What was the problem/Ticket Number

closes #183 

### How does this solve the problem?

Checks `error.code` (`ENOENT`) rather than `error.errno` (`-2`) when displaying error.

https://github.com/sindresorhus/execa#handling-errors

### How to duplicate the issue

  1. `mv node_modules/.bin/eslint node_modules/.bin/eslint.bak`
  2. Call `eslint-watch`
